### PR TITLE
nsxiv-env: Make more robust

### DIFF
--- a/scripts/nsxiv-env/README.md
+++ b/scripts/nsxiv-env/README.md
@@ -12,8 +12,8 @@ your `PATH` before `nsxiv` (the actual binary) you will have to use the entire
 path to call `nsxiv`, otherwise the script will go into an infinite recursion.
 
 ```diff
--nsxiv $NSXIV_OPTS -- "$@"
-+/path/to/nsxiv $NSXIV_OPTS -- "$@"
+-exec nsxiv $NSXIV_OPTS "$@"
++exec /path/to/nsxiv $NSXIV_OPTS "$@"
 ```
 
 ## Authors

--- a/scripts/nsxiv-env/nsxiv-env
+++ b/scripts/nsxiv-env/nsxiv-env
@@ -1,14 +1,6 @@
 #!/usr/bin/env sh
 
-NSXIV_OPTS="${NSXIV_OPTS:-"-a -q"}"
-# set default args here    ^   ^  inside the quotes
+NSXIV_OPTS=${NSXIV_OPTS:-"-a -q"}
+# set default args here   ^   ^  inside the quotes
 
-while getopts A:abce:fG:g:hin:N:opqrS:s:T:tvZz: opt; do
-  case $opt in
-    [a-z]|[A-Z]) NSXIV_OPTS="$NSXIV_OPTS -$opt $OPTARG" ;;
-    *) exit 1 ;;
-  esac
-done
-shift "$((OPTIND-1))"
-
-nsxiv $NSXIV_OPTS -- "$@"
+exec nsxiv $NSXIV_OPTS "$@"


### PR DESCRIPTION
I didn't understand why we duplicated the options parsing here. It
was completely unnecessary and seemed fragile if new options were added
upstream (or in a fork). The script is now much dumber and just passes
the prepends the default args the input given and invokes nsxiv. Args
appearing latter will override earlier ones and the env var can still be
cleared if needed.

Also silenced shellcheck errors.