### PR TITLE
Add `nsxiv-pipe` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ them to fit their use-cases.
 | [nsxiv-rifle](scripts/nsxiv-rifle) | Open all images in a directory. |
 | [nsxiv-saver](scripts/nsxiv-saver) | Use nsxiv as a xsecurelock screensaver. |
 | [subtube](https://github.com/nagy135/subtube) | Watch subscribed youtubed videos. |
+| [nsxiv-pipe](scripts/nsxiv-pipe) | Pipe images into nsxiv |
 
 ## Tips and Tricks
 

--- a/scripts/nsxiv-pipe/README.md
+++ b/scripts/nsxiv-pipe/README.md
@@ -1,0 +1,8 @@
+# nsxiv-pipe
+
+This script allows piping images into `nsxiv`. It replaces all arguments
+containing a single dash (`-`) with a temporal file created from stdin.
+
+# Authors
+
+* mamg22 <marcomonizg@gmail.com>

--- a/scripts/nsxiv-pipe/nsxiv-pipe
+++ b/scripts/nsxiv-pipe/nsxiv-pipe
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+cache_dir="/tmp/nsxiv-pipe"
+
+tmpfile="$cache_dir/stdin.$$"
+
+cleanup()
+{
+    rm -f -- "$tmpfile"
+}
+trap cleanup EXIT
+
+mkdir -p "$cache_dir"
+# Consume stdin and put it in the temporal file
+cat > "$tmpfile"
+
+if [ "$#" -eq 0 ]; then
+    echo "nsxiv-pipe: No arguments provided" >&2
+    exit 1
+fi
+
+# Pop from the beginning, convert if needed and push at the end
+for arg in "$@"; do
+    if [ "$arg" = "-" ]; then
+        arg="$tmpfile"
+    fi
+    shift
+    set -- "$@" "$arg"
+done
+
+nsxiv "$@"


### PR DESCRIPTION
This script will allow piping images into `nsxiv`, replacing any `-` in the arguments with the piped image.

It require creating a temporary file, if disk read/write aren't desired, users can put `cache_dir` in some directory under `tmpfs` or `zram`, if it isn't already in one of those (now that I think about it, that tip could be included in the readme).

Created as a solution for nsxiv/nsxiv#32, which I was hoping to get in nsxiv.