### PR TITLE
patch: zoom-per-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ merge conflicts or broken functionality on upgrade.
 | [dmenu-mode](patches/dmenu-mode) | Add dmenu mode to nsxiv |
 | [image-mode-cycle](patches/image-mode-cycle) | Cycle when viewing multiple images |
 | [toggle-winbg](patches/toggle-winbg) | Keybinding to toggle the window background color |
+| [zoom-per-image](patches/zoom-per-image) | Remember what the zoom for image was |
 
 For patch submissions please use the following format:
 

--- a/patches/zoom-per-image/README.md
+++ b/patches/zoom-per-image/README.md
@@ -1,0 +1,8 @@
+# zoom-per-image
+
+This patch will make nsxiv remember which zoom the image had before.
+The zoom is forgotten if you scale any image to fit window.
+
+## Authors
+
+* lucas mior \<lucas.mior at tutamail dot com>

--- a/patches/zoom-per-image/zoom-per-image-v28.diff
+++ b/patches/zoom-per-image/zoom-per-image-v28.diff
@@ -38,7 +38,8 @@ index f2b3b09..1be574a 100644
  bool img_zoom(img_t *img, int d)
  {
  	int i = d > 0 ? 0 : ARRLEN(zoom_levels)-1;
-+	img->zoom = files[fileidx].zoom;
++	if(files[fileidx].zoom)
++		img->zoom = files[fileidx].zoom;
  	while (i >= 0 && i < ARRLEN(zoom_levels) && (d > 0 ?
  	       zoom_levels[i]/100 <= img->zoom : zoom_levels[i]/100 >= img->zoom))
  	{

--- a/patches/zoom-per-image/zoom-per-image-v28.diff
+++ b/patches/zoom-per-image/zoom-per-image-v28.diff
@@ -1,0 +1,75 @@
+diff --git a/image.c b/image.c
+index f2b3b09..1be574a 100644
+--- a/image.c
++++ b/image.c
+@@ -28,6 +28,9 @@
+ #include <sys/types.h>
+ #include <unistd.h>
+ 
++extern fileinfo_t *files;
++extern int filecnt, fileidx;
++
+ #if HAVE_LIBEXIF
+ #include <libexif/exif-data.h>
+ #endif
+@@ -496,8 +499,10 @@ static bool img_fit(img_t *img)
+ {
+ 	float z, zw, zh;
+ 
+-	if (img->scalemode == SCALE_ZOOM)
+-		return false;
++	if (img->scalemode == SCALE_ZOOM && files[fileidx].zoom != 0) {
++		img_zoom_to(img, files[fileidx].zoom);
++		return true;
++	}
+ 
+ 	zw = (float) img->win->w / (float) img->w;
+ 	zh = (float) img->win->h / (float) img->h;
+@@ -519,7 +524,7 @@ static bool img_fit(img_t *img)
+ 	z = MIN(z, img->scalemode == SCALE_DOWN ? 1.0 : ZOOM_MAX);
+ 
+ 	if (ABS(img->zoom - z) > 1.0/MAX(img->w, img->h)) {
+-		img->zoom = z;
++		files[fileidx].zoom = img->zoom = z;
+ 		img->dirty = true;
+ 		return true;
+ 	} else {
+@@ -691,12 +696,14 @@ bool img_zoom_to(img_t *img, float z)
+ bool img_zoom(img_t *img, int d)
+ {
+ 	int i = d > 0 ? 0 : ARRLEN(zoom_levels)-1;
++	img->zoom = files[fileidx].zoom;
+ 	while (i >= 0 && i < ARRLEN(zoom_levels) && (d > 0 ?
+ 	       zoom_levels[i]/100 <= img->zoom : zoom_levels[i]/100 >= img->zoom))
+ 	{
+ 		i += d;
+ 	}
+ 	i = MIN(MAX(i, 0), ARRLEN(zoom_levels)-1);
++	files[fileidx].zoom = zoom_levels[i]/100;
+ 	return img_zoom_to(img, zoom_levels[i]/100);
+ }
+ 
+diff --git a/main.c b/main.c
+index e70c642..791b3c9 100644
+--- a/main.c
++++ b/main.c
+@@ -132,6 +132,7 @@ static void check_add_file(char *filename, bool given)
+ 
+ 	files[fileidx].name = estrdup(filename);
+ 	files[fileidx].path = path;
++	files[fileidx].zoom = 0;
+ 	if (given)
+ 		files[fileidx].flags |= FF_WARN;
+ 	fileidx++;
+diff --git a/nsxiv.h b/nsxiv.h
+index 8d5af02..db0fc62 100644
+--- a/nsxiv.h
++++ b/nsxiv.h
+@@ -126,6 +126,7 @@ typedef struct {
+ 	const char *name; /* as given by user */
+ 	const char *path; /* always absolute */
+ 	fileflags_t flags;
++	float zoom;
+ } fileinfo_t;
+ 
+ /* timeouts in milliseconds: */


### PR DESCRIPTION
This patch will make nsxiv remember which zoom the image had before.
The zoom is forgotten if you scale any image to fit window.