### PR TITLE
ci: Use newest patch on tests and exit non-zero on fail

### DIFF
--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         cd nsxiv
         find "$PWD"/../patches -type f -name '*.patch' |
-          xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' |
+          ( cd .. && xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' ) |
           sort -rn | {
             while read -r timestamp patchpath; do
               patchdir="${patchpath%/*}"

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -18,25 +18,9 @@ jobs:
         git clone 'https://github.com/nsxiv/nsxiv.git'
     - name: apply-patches
       run: |
-        cd nsxiv
-        find "$PWD"/../patches -type f -name '*.patch' |
-          ( cd .. && xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' ) |
-          sort -rn | {
-            while read -r timestamp patchpath; do
-              patchdir="${patchpath%/*}"
-              patchdir="${patchdir##*/}"
+        for dir in "$PWD"/patches/*/; do
+          find "$dir" \( -name '*.patch' -o -name '*.diff' \) -print |
+          xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' |
+          sort -nr | head -n 1 | cut -d ' ' -f 2
+        done | ( cd nsxiv && xargs -I{} /bin/sh -c 'if ! git apply --check {} 2>/dev/null; then echo "[FAILED]: $(basename {})"; fi' )
 
-              for applied in "$@"; do
-                if [ "$patchdir" = "$applied" ]; then
-                  continue 2
-                fi
-              done
-              set -- "$@" "$patchdir"
-
-              if ! git apply --check "$patchpath" 2>/dev/null; then
-                echo "[FAILED]: $(basename "$patchpath")" >&2
-                fail=1
-              fi
-            done
-            exit "${fail:-0}"
-          }

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         for dir in "$PWD"/patches/*/; do
           find "$dir" \( -name '*.patch' -o -name '*.diff' \) -print |
-          xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' |
+          xargs -I{} -n 1 git log --format=format:'%ct {}%n' -- '{}' |
           sort -nr | head -n 1 | cut -d ' ' -f 2
         done | ( cd nsxiv && xargs -I{} /bin/sh -c 'if ! git apply --check {} 2>/dev/null; then echo "[FAILED]: $(basename {})"; fi' )
 

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -17,9 +17,27 @@ jobs:
         sudo apt-get install git
         git clone 'https://github.com/nsxiv/nsxiv.git'
     - name: apply-patches
-      # FIXME: only apply the latest patch rather than everything
-      # TODO: exit with non-zero status if any of the patches fails to apply
       run: |
         cd nsxiv
         find ../patches -type f -name '*.patch' |
-          xargs -I{} /bin/sh -c 'git apply --check {} 2>/dev/null || echo "[FAILED]: $(basename {})"'
+          xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' |
+          sort -rn | {
+            while read -r timestamp patchpath; do
+              patchdir="${patchpath%/*}"
+              patchdir="${patchdir##*/}"
+
+              for applied in "$@"; do
+                if [ "$patchdir" = "$applied" ]; then
+                  continue 2
+                fi
+              done
+              # Append the patch directory name to the list
+              set -- "$@" "$patchdir"
+
+              git apply --check "$patchpath" 2>/dev/null || {
+                echo "[FAILED]: $(basename "$patchpath")"
+                fail=1
+              }
+              done
+              exit "${fail:-0}"
+            }

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -31,13 +31,12 @@ jobs:
                   continue 2
                 fi
               done
-              # Append the patch directory name to the list
               set -- "$@" "$patchdir"
 
-              git apply --check "$patchpath" 2>/dev/null || {
-                echo "[FAILED]: $(basename "$patchpath")"
+              if ! git apply --check "$patchpath" 2>/dev/null; then
+                echo "[FAILED]: $(basename "$patchpath")" >&2
                 fail=1
-              }
-              done
-              exit "${fail:-0}"
-            }
+              fi
+            done
+            exit "${fail:-0}"
+          }

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -19,7 +19,7 @@ jobs:
     - name: apply-patches
       run: |
         cd nsxiv
-        find ../patches -type f -name '*.patch' |
+        find "$PWD"/../patches -type f -name '*.patch' |
           xargs -I{} -n 1 git log --format=format:'%at {}%n' -- '{}' |
           sort -rn | {
             while read -r timestamp patchpath; do


### PR DESCRIPTION
As suggested in https://github.com/nsxiv/nsxiv-extra/commit/82645084574125b1c65af7eda31fa9f91ce411a4

This uses the author commit time for sorting (`%at` in the log format).